### PR TITLE
feat(pulse): real-time status, thinking blocks, and todo cards

### DIFF
--- a/octomate/agents/pulse.py
+++ b/octomate/agents/pulse.py
@@ -15,6 +15,7 @@ Usage::
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
@@ -43,11 +44,40 @@ from octomate.transmuters.interactions import Todo
 if TYPE_CHECKING:
     from pydantic_ai.messages import ModelMessage
 
-    from octomate.tentacles.base import AgentTentacle, ChannelTentacle
+    from octomate.tentacles.base import AgentTentacle, ChannelTentacle, StreamSink
 
+from pydantic_ai.messages import PartEndEvent, ThinkingPart
+from pydantic_ai.run import AgentRunResultEvent
+from pydantic_ai.settings import ModelSettings
+
+logger = logging.getLogger(__name__)
 AgentOutputT = TypeVar("AgentOutputT")
 
 SYSTEM_PROMPT = BASE_PROMPT + FLICK_EXTRA
+
+
+async def run_streaming(
+    agent: Agent[SessionContext, AgentOutputT],
+    stream: StreamSink | None,
+    **kwargs: Any,
+) -> AgentRunResult[AgentOutputT]:
+    if not stream:
+        return await agent.run(**kwargs)
+    try:
+        result: AgentRunResult[AgentOutputT] | None = None
+        async for event in agent.run_stream_events(**kwargs):
+            if isinstance(event, AgentRunResultEvent):
+                result = event.result
+            elif isinstance(event, PartEndEvent) and isinstance(
+                event.part, ThinkingPart
+            ):
+                if event.part.content:
+                    await stream.post_thinking_block(event.part.content)
+        assert result is not None, "The stream run did not produce a result"
+        return result
+    except (AssertionError, NotImplementedError):
+        return await agent.run(**kwargs)
+
 
 TriageOutput = list[AgentMessage] | list[Todo] | DeferredToolRequests
 
@@ -106,7 +136,7 @@ def create_pulse_agents(
 ) -> PulseAgents:
     http_client = httpx.AsyncClient(
         transport=RetryTransport(httpx.AsyncHTTPTransport()),
-        timeout=httpx.Timeout(10.0),
+        timeout=httpx.Timeout(180.0),
     )
     kwargs: dict[str, Any] = {"http_client": http_client}
     if config.base_url:
@@ -122,6 +152,9 @@ def create_pulse_agents(
             kwargs["api_key"] = config.api_key
     provider = GoogleProvider(**kwargs)
     model = GoogleModel(config.model, provider=provider)
+    model_settings = (
+        ModelSettings(thinking=config.thinking) if config.thinking else None
+    )
 
     skill_toolsets = skill_manager.build_skillsets() if skill_manager else []
     triage_toolsets = [*skill_toolsets]
@@ -134,6 +167,7 @@ def create_pulse_agents(
         deps_type=SessionContext,
         output_type=[list[AgentMessage], list[Todo], DeferredToolRequests],
         toolsets=triage_toolsets or None,
+        model_settings=model_settings,
     )
     step = Agent(
         model,
@@ -141,12 +175,14 @@ def create_pulse_agents(
         deps_type=SessionContext,
         output_type=str,
         toolsets=skill_toolsets or None,
+        model_settings=model_settings,
     )
     synthesize = Agent(
         model,
         system_prompt=BASE_PROMPT,
         deps_type=SessionContext,
         output_type=list[AgentMessage],
+        model_settings=model_settings,
     )
 
     return PulseAgents(triage=triage, step=step, synthesize=synthesize)
@@ -181,6 +217,7 @@ class PulseState:
     prompt: str | list
     todos: list[Todo] = field(default_factory=list)
     step_outputs: list[str] = field(default_factory=list)
+    card_ref: str | None = None
 
     @property
     def goal(self) -> str:
@@ -199,6 +236,7 @@ class PulseDeps:
     toolsets: list[FunctionToolset[SessionContext]] | None = None
     instructions: str | None = None
     message_history: list[ModelMessage] | None = None
+    stream: StreamSink | None = None
 
 
 async def resolve_deferred(
@@ -207,6 +245,7 @@ async def resolve_deferred(
     tentacle: ChannelTentacle,
     deps: SessionContext,
     toolsets: list[FunctionToolset[SessionContext]] | None = None,
+    stream: StreamSink | None = None,
 ) -> AgentRunResult[AgentOutputT]:
     """Resolve deferred tool calls (HITL interactions) until the agent produces output.
 
@@ -326,7 +365,9 @@ async def resolve_deferred(
 
             deferred.approvals[call.tool_call_id] = approved
 
-        result = await agent.run(
+        result = await run_streaming(
+            agent,
+            stream,
             message_history=result.all_messages(),
             deferred_tool_results=deferred,
             deps=deps,
@@ -343,30 +384,68 @@ class Triage(BaseNode[PulseState, PulseDeps, list[AgentMessage]]):
     async def run(
         self, ctx: GraphRunContext[PulseState, PulseDeps]
     ) -> ExecuteStep | End[list[AgentMessage]]:
+        key = ctx.deps.agent_deps.session_key if ctx.deps.agent_deps else None
+        logger.info("[%s] Triage started", key)
+
+        if ctx.deps.stream:
+            await ctx.deps.stream.set_status("Thinking…")
+
         triage_instructions = TRIAGE_INSTRUCTION
         if ctx.deps.instructions:
             triage_instructions = f"{ctx.deps.instructions}\n\n{TRIAGE_INSTRUCTION}"
 
-        result = await ctx.deps.triage.run(
-            ctx.state.prompt,
+        result = await run_streaming(
+            ctx.deps.triage,
+            ctx.deps.stream,
+            user_prompt=ctx.state.prompt,
             deps=ctx.deps.agent_deps,
             toolsets=ctx.deps.toolsets,
             instructions=triage_instructions,
             message_history=ctx.deps.message_history,
         )
         if isinstance(result.output, DeferredToolRequests):
+            logger.debug("[%s] Triage returned deferred tools, resolving", key)
             result = await resolve_deferred(
                 ctx.deps.triage,
                 result,
                 ctx.deps.tentacle,
                 ctx.deps.agent_deps,
                 ctx.deps.toolsets,
+                ctx.deps.stream,
             )
 
         output = result.output
         if isinstance(output, list) and output and isinstance(output[0], Todo):
             ctx.state.todos = [t for t in output if isinstance(t, Todo)]
+            logger.info("[%s] Triage produced %d plan steps", key, len(ctx.state.todos))
+
+            if ctx.deps.stream:
+                await ctx.deps.stream.set_status("Planning…")
+
+            if ctx.deps.tentacle and key:
+                persisted = []
+                for t in ctx.state.todos:
+                    db_todo = await ctx.deps.tentacle.feelers.todos.create_todo(
+                        key, title=t.title
+                    )
+                    persisted.append(
+                        t.model_copy(update={"todo_id": db_todo.todo_id})
+                        if db_todo.todo_id
+                        else t
+                    )
+                ctx.state.todos = persisted
+                ctx.state.card_ref = (
+                    await ctx.deps.tentacle.feelers.todos.upsert_todo_list(
+                        key, ctx.state.todos
+                    )
+                )
+                if ctx.state.card_ref:
+                    await ctx.deps.tentacle.feelers.todos.pin_todo(
+                        key, ctx.state.card_ref
+                    )
+
             return ExecuteStep()
+        logger.info("[%s] Triage answered directly", key)
         return End(output)  # type: ignore[arg-type]
 
 
@@ -377,9 +456,23 @@ class ExecuteStep(BaseNode[PulseState, PulseDeps]):
     async def run(
         self, ctx: GraphRunContext[PulseState, PulseDeps]
     ) -> ExecuteStep | Synthesize:
-        current = next((t for t in ctx.state.todos if t.status == "pending"), None)
+        key = ctx.deps.agent_deps.session_key if ctx.deps.agent_deps else None
+        pending = [t for t in ctx.state.todos if t.status == "pending"]
+        current = pending[0] if pending else None
         if current is None:
+            logger.info("[%s] All steps done, moving to synthesize", key)
             return Synthesize()
+
+        step_index = len(ctx.state.todos) - len(pending) + 1
+        total = len(ctx.state.todos)
+        logger.info(
+            "[%s] Executing step '%s' (%d/%d)", key, current.title, step_index, total
+        )
+
+        if ctx.deps.stream:
+            await ctx.deps.stream.set_status(
+                f"Working on: {current.title} ({step_index}/{total})"
+            )
 
         context = (
             "\n".join(ctx.state.step_outputs) if ctx.state.step_outputs else "(none)"
@@ -390,8 +483,10 @@ class ExecuteStep(BaseNode[PulseState, PulseDeps]):
             title=current.title,
             description=current.description,
         )
-        result = await ctx.deps.step.run(
-            current.title,
+        result = await run_streaming(
+            ctx.deps.step,
+            ctx.deps.stream,
+            user_prompt=current.title,
             deps=ctx.deps.agent_deps,
             message_history=ctx.deps.message_history,
             instructions=step_instructions,
@@ -402,15 +497,23 @@ class ExecuteStep(BaseNode[PulseState, PulseDeps]):
                 result,
                 ctx.deps.tentacle,
                 ctx.deps.agent_deps,
+                stream=ctx.deps.stream,
             )
         ctx.state.step_outputs.append(f"- {current.title}: {result.output}")
 
         ctx.state.todos = [
-            t.model_copy(update={"status": "done"})
+            t.model_copy(update={"status": "completed"})
             if t.todo_id == current.todo_id
             else t
             for t in ctx.state.todos
         ]
+
+        if ctx.deps.tentacle and key and current.todo_id:
+            await ctx.deps.tentacle.feelers.todos.update_todo(current.todo_id, "completed")
+            ctx.state.card_ref = await ctx.deps.tentacle.feelers.todos.upsert_todo_list(
+                key, ctx.state.todos, existing_ts=ctx.state.card_ref
+            )
+
         return ExecuteStep()
 
 
@@ -421,14 +524,33 @@ class Synthesize(BaseNode[PulseState, PulseDeps, list[AgentMessage]]):
     async def run(
         self, ctx: GraphRunContext[PulseState, PulseDeps]
     ) -> End[list[AgentMessage]]:
+        key = ctx.deps.agent_deps.session_key if ctx.deps.agent_deps else None
+        logger.info(
+            "[%s] Synthesize started (%d step outputs)",
+            key,
+            len(ctx.state.step_outputs),
+        )
+
+        if ctx.deps.stream:
+            await ctx.deps.stream.set_status("Wrapping up…")
+
         results_block = "\n".join(ctx.state.step_outputs)
         synth_instructions = SYNTHESIZE_INSTRUCTION.format(results=results_block)
-        result = await ctx.deps.synthesize.run(
-            ctx.state.goal,
+        result = await run_streaming(
+            ctx.deps.synthesize,
+            ctx.deps.stream,
+            user_prompt=ctx.state.goal,
             deps=ctx.deps.agent_deps,
             message_history=ctx.deps.message_history,
             instructions=synth_instructions,
         )
+        logger.info("[%s] Synthesize complete", key)
+
+        if ctx.deps.tentacle and key and ctx.state.card_ref:
+            await ctx.deps.tentacle.feelers.todos.unpin_todo(
+                key, ctx.state.card_ref
+            )
+
         return End(result.output)
 
 

--- a/octomate/config.py
+++ b/octomate/config.py
@@ -25,6 +25,7 @@ class FlickConfig(BaseModel):
     vertexai: bool = False
     project: str = ""
     location: str = ""
+    thinking: bool | Literal["minimal", "low", "medium", "high", "xhigh"] = "medium"
 
 
 class Mem0Config(Mem0MemoryConfig):
@@ -84,11 +85,13 @@ TentacleConfigUnion = Annotated[
 ]
 
 
-class SshConfig(BaseModel):
+class SSHConfig(BaseModel):
     host: str  # user@remote-host
     identity_file: str | None = None
     ssh_options: list[str] = []
-    claude_bin: str = "claude"  # path to claude CLI on remote, e.g. ~/.claude/local/claude
+    claude_bin: str = (
+        "claude"  # path to claude CLI on remote, e.g. ~/.claude/local/claude
+    )
 
 
 class ClaudeCodeConfig(BaseModel):
@@ -101,7 +104,7 @@ class ClaudeCodeConfig(BaseModel):
     worktrees_dir: str | None = (
         None  # if set, enables per-session git worktree isolation
     )
-    ssh: SshConfig | None = None  # if set, runs Claude Code on the remote host via SSH
+    ssh: SSHConfig | None = None  # if set, runs Claude Code on the remote host via SSH
 
 
 class CopilotConfig(BaseModel):

--- a/octomate/tentacles/base.py
+++ b/octomate/tentacles/base.py
@@ -296,20 +296,24 @@ class ChannelTentacle(Tentacle):
 
             deps = SessionContext(session_key=key, tentacle=self)
             state = PulseState(prompt=user_prompt)
-            pulse_deps = PulseDeps(
-                triage=self.agents.triage,
-                step=self.agents.step,
-                synthesize=self.agents.synthesize,
-                agent_deps=deps,
-                tentacle=self,
-                toolsets=self.toolsets,
-                instructions=instructions,
-                message_history=await self.memory.history(key, size=32),
-            )
-            graph_result = await pulse_graph.run(Triage(), state=state, deps=pulse_deps)
+            async with self.open_stream(key) as stream:
+                pulse_deps = PulseDeps(
+                    triage=self.agents.triage,
+                    step=self.agents.step,
+                    synthesize=self.agents.synthesize,
+                    agent_deps=deps,
+                    tentacle=self,
+                    toolsets=self.toolsets,
+                    instructions=instructions,
+                    message_history=await self.memory.history(key, size=32),
+                    stream=stream,
+                )
+                graph_result = await pulse_graph.run(
+                    Triage(), state=state, deps=pulse_deps
+                )
 
-            for msg_out in graph_result.output:
-                await self.twitch(key, msg_out.segments)
+                for msg_out in graph_result.output:
+                    await self.twitch(key, msg_out.segments)
             asyncio.create_task(self.memory.memo(key, graph_result.output, self))
         except Exception:
             logger.exception("Error in tentacle %s [%s]", self.id, key)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,6 +4,8 @@ import asyncio
 import contextlib
 import json
 import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
@@ -28,7 +30,7 @@ from octomate.schemas.session import SessionKey, UserProfile
 from octomate.stores.interaction import InteractionStore
 from octomate.stores.message import MessageStore
 from octomate.stores.thread import ThreadStore
-from octomate.tentacles.base import ChannelTentacle, PlatformMessage
+from octomate.tentacles.base import ChannelTentacle, PlatformMessage, StreamSink
 from octomate.tentacles.feelers import NULL_FEELERS
 from octomate.transmuters.messages import Message
 from octomate.transmuters.threads import Thread
@@ -127,6 +129,23 @@ class MockOctopusMemory(OctopusMemory):
         self.messages = MockMessageStore()
 
 
+class NullStreamSink(StreamSink):
+    def __init__(self) -> None:
+        pass
+
+    async def set_status(self, status: str) -> None:
+        pass
+
+    async def append(self, text: str) -> None:
+        pass
+
+    async def flush(self) -> None:
+        pass
+
+    async def post_thinking_block(self, text: str) -> None:
+        pass
+
+
 class MockTentacle(ChannelTentacle):
     sent: list[tuple[SessionKey, list[AgentSegment]]]
     confirmations_requested: int
@@ -146,9 +165,7 @@ class MockTentacle(ChannelTentacle):
             output_type=[list[AgentMessage], list[Todo], DeferredToolRequests],
         )
         step = Agent("test", deps_type=SessionContext, output_type=str)
-        synth = Agent(
-            "test", deps_type=SessionContext, output_type=list[AgentMessage]
-        )
+        synth = Agent("test", deps_type=SessionContext, output_type=list[AgentMessage])
         agents = PulseAgents(triage=triage, step=step, synthesize=synth)
         super().__init__(tag, octopus, agents, memory, flush_delay=flush_delay)
         self.threads = MockThreadStore(default_owner=tag)
@@ -163,6 +180,10 @@ class MockTentacle(ChannelTentacle):
 
     async def deactivate(self) -> None:
         pass
+
+    @asynccontextmanager
+    async def open_stream(self, key: SessionKey) -> AsyncIterator[StreamSink]:
+        yield NullStreamSink()
 
     async def twitch(self, key: SessionKey, segments: list[AgentSegment]) -> None:
         self.sent.append((key, list(segments)))

--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from pydantic_ai import Agent, ModelResponse, TextPart, ToolCallPart
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 
-from octomate.agents.pulse import PulseAgents
 from octomate.agents.pulse import (
+    PulseAgents,
     PulseDeps,
     PulseState,
     Triage,
@@ -37,10 +37,10 @@ def _todo_tool_call(todos: list[dict[str, str]]) -> ModelResponse:
 
 def _make_agents() -> PulseAgents:
     """Create test agents with simple output types."""
-    triage: Agent[None, str] = Agent("test", output_type=[str, list[Todo]])
-    step: Agent[None, str] = Agent("test", output_type=str)
-    synth: Agent[None, str] = Agent("test", output_type=str)
-    return PulseAgents(triage=triage, step=step, synthesize=synth)
+    triage = Agent("test", output_type=[str, list[Todo]])
+    step = Agent("test", output_type=str)
+    synth = Agent("test", output_type=str)
+    return PulseAgents(triage=triage, step=step, synthesize=synth)  # type: ignore[arg-type]
 
 
 def _make_deps(agents: PulseAgents) -> PulseDeps:
@@ -111,8 +111,16 @@ async def test_plan_path_runs_all_steps():
 async def test_steps_tracked_as_todos():
     """Plan steps in the graph state are Todo objects marked done after execution."""
     todos = [
-        {"todo_id": "pulse-0", "title": "Summarize", "description": "Summarize the document"},
-        {"todo_id": "pulse-1", "title": "Compare", "description": "Compare against last quarter"},
+        {
+            "todo_id": "pulse-0",
+            "title": "Summarize",
+            "description": "Summarize the document",
+        },
+        {
+            "todo_id": "pulse-1",
+            "title": "Compare",
+            "description": "Compare against last quarter",
+        },
     ]
 
     call_count = 0
@@ -134,7 +142,7 @@ async def test_steps_tracked_as_todos():
 
     assert len(state.todos) == 2
     assert all(isinstance(t, Todo) for t in state.todos)
-    assert all(t.status == "done" for t in state.todos)
+    assert all(t.status == "completed" for t in state.todos)
     assert state.todos[0].title == "Summarize"
     assert state.todos[0].description == "Summarize the document"
     assert state.todos[1].title == "Compare"
@@ -154,9 +162,21 @@ async def test_full_pipeline_no_internal_leakage():
     """Internal plan details must not leak into the final answer."""
     call_count = 0
     todos = [
-        {"todo_id": "pulse-0", "title": "Summarize", "description": "Summarize key findings"},
-        {"todo_id": "pulse-1", "title": "Compare", "description": "Compare with baseline"},
-        {"todo_id": "pulse-2", "title": "Recommend", "description": "Produce final recommendation"},
+        {
+            "todo_id": "pulse-0",
+            "title": "Summarize",
+            "description": "Summarize key findings",
+        },
+        {
+            "todo_id": "pulse-1",
+            "title": "Compare",
+            "description": "Compare with baseline",
+        },
+        {
+            "todo_id": "pulse-2",
+            "title": "Recommend",
+            "description": "Produce final recommendation",
+        },
     ]
 
     def triage_fn(messages: list, info: AgentInfo) -> ModelResponse:
@@ -196,7 +216,11 @@ async def test_synthesize_uses_native_output_type():
     """Synthesize returns in the synth agent's configured output type."""
     call_count = 0
     todos = [
-        {"todo_id": "pulse-0", "title": "Research", "description": "Research the topic"},
+        {
+            "todo_id": "pulse-0",
+            "title": "Research",
+            "description": "Research the topic",
+        },
         {"todo_id": "pulse-1", "title": "Write", "description": "Write the summary"},
     ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1856,14 +1856,14 @@ wheels = [
 
 [[package]]
 name = "nexus-rpc"
-version = "1.2.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/50/95d7bc91f900da5e22662c82d9bf0f72a4b01f2a552708bf2f43807707a1/nexus_rpc-1.2.0.tar.gz", hash = "sha256:b4ddaffa4d3996aaeadf49b80dfcdfbca48fe4cb616defaf3b3c5c2c8fc61890", size = 74142, upload-time = "2025-11-17T19:17:06.798Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/d5/cd1ffb202b76ebc1b33c1332a3416e55a39929006982adc2b1eb069aaa9b/nexus_rpc-1.4.0.tar.gz", hash = "sha256:3b8b373d4865671789cc43623e3dc0bcbf192562e40e13727e17f1c149050fba", size = 82367, upload-time = "2026-02-25T22:01:34.053Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/04/eaac430d0e6bf21265ae989427d37e94be5e41dc216879f1fbb6c5339942/nexus_rpc-1.2.0-py3-none-any.whl", hash = "sha256:977876f3af811ad1a09b2961d3d1ac9233bda43ff0febbb0c9906483b9d9f8a3", size = 28166, upload-time = "2025-11-17T19:17:05.64Z" },
+    { url = "https://files.pythonhosted.org/packages/11/52/6327a5f4fda01207205038a106a99848a41c83e933cd23ea2cab3d2ebc6c/nexus_rpc-1.4.0-py3-none-any.whl", hash = "sha256:14c953d3519113f8ccec533a9efdb6b10c28afef75d11cdd6d422640c40b3a49", size = 29645, upload-time = "2026-02-25T22:01:33.122Z" },
 ]
 
 [[package]]
@@ -1992,7 +1992,7 @@ requires-dist = [
     { name = "mem0ai", specifier = ">=0.1" },
     { name = "pixivpy-async", specifier = ">=1.2.14" },
     { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "pydantic-ai", specifier = ">=1.68.0" },
+    { name = "pydantic-ai", specifier = ">=1.80.0" },
     { name = "pydantic-settings", specifier = ">=2" },
     { name = "pymilvus", specifier = ">=2.6.9" },
     { name = "pyyaml", specifier = ">=6" },
@@ -2014,7 +2014,7 @@ dev = [
 
 [[package]]
 name = "openai"
-version = "2.26.0"
+version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2026,9 +2026,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/91/2a06c4e9597c338cac1e5e5a8dd6f29e1836fc229c4c523529dca387fda8/openai-2.26.0.tar.gz", hash = "sha256:b41f37c140ae0034a6e92b0c509376d907f3a66109935fba2c1b471a7c05a8fb", size = 666702, upload-time = "2026-03-05T23:17:35.874Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/fe/64b3d035780b3188f86c4f6f1bc202e7bb74757ef028802112273b9dcacf/openai-2.31.0.tar.gz", hash = "sha256:43ca59a88fc973ad1848d86b98d7fac207e265ebbd1828b5e4bdfc85f79427a5", size = 684772, upload-time = "2026-04-08T21:01:41.797Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/2e/3f73e8ca53718952222cacd0cf7eecc9db439d020f0c1fe7ae717e4e199a/openai-2.26.0-py3-none-any.whl", hash = "sha256:6151bf8f83802f036117f06cc8a57b3a4da60da9926826cc96747888b57f394f", size = 1136409, upload-time = "2026-03-05T23:17:34.072Z" },
+    { url = "https://files.pythonhosted.org/packages/66/bc/a8f7c3aa03452fedbb9af8be83e959adba96a6b4a35e416faffcc959c568/openai-2.31.0-py3-none-any.whl", hash = "sha256:44e1344d87e56a493d649b17e2fac519d1368cbb0745f59f1957c4c26de50a0a", size = 1153479, upload-time = "2026-04-08T21:01:39.217Z" },
 ]
 
 [[package]]
@@ -2604,19 +2604,19 @@ email = [
 
 [[package]]
 name = "pydantic-ai"
-version = "1.68.0"
+version = "1.80.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic-ai-slim", extra = ["ag-ui", "anthropic", "bedrock", "cli", "cohere", "evals", "fastmcp", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "retries", "temporal", "ui", "vertexai", "xai"] },
+    { name = "pydantic-ai-slim", extra = ["ag-ui", "anthropic", "bedrock", "cli", "cohere", "evals", "fastmcp", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "retries", "spec", "temporal", "ui", "vertexai", "xai"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/a7/562d14df67305a54c34bbde58b94e70790ba1486e125e9f6b7567a31e16f/pydantic_ai-1.68.0.tar.gz", hash = "sha256:9ecae11776b640096d75ca69eca6e122702c7e82f2924bf3a077b781a8d371f6", size = 12178, upload-time = "2026-03-13T03:39:06.358Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/fa/74ebb63cab77331fd98124e6665bff1634415a739a5f4aba077ce34f0e81/pydantic_ai-1.80.0.tar.gz", hash = "sha256:93aa897fac720cd9e11b4f47b0c456649cc72f4b65e575eddfd9adbecc200b81", size = 12793, upload-time = "2026-04-10T23:31:17.844Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/97/8aa45378ff43b27b6505bd78c161ab3d2450d27b16b3f16622ad5edd315f/pydantic_ai-1.68.0-py3-none-any.whl", hash = "sha256:d4740389e3a9230934b1bd9f39880c07debad9f19d0ee3ab92ac28826b8612f5", size = 7226, upload-time = "2026-03-13T03:38:58.048Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9a/6d65ea560f8e84f57cf5cf7f5b611d48bd5d1869120bc7fcc3b40aed0556/pydantic_ai-1.80.0-py3-none-any.whl", hash = "sha256:71d0117a7c55116c00d7dfdc973f0bead056709608b251f83a884821341177ee", size = 7549, upload-time = "2026-04-10T23:31:09.674Z" },
 ]
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.68.0"
+version = "1.80.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "genai-prices" },
@@ -2627,9 +2627,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/00/3e48684694e424a8d05dc1538fe53322854b0290fbb494f0007db62cd243/pydantic_ai_slim-1.68.0.tar.gz", hash = "sha256:38edda1dbe20137326903d8a223a9f4901d62b0a70799842cae3c7d60b3bebd2", size = 436924, upload-time = "2026-03-13T03:39:08.572Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/27/aa309951a8973a8525fdf9e45b49960105bc78ebc8dba48366c2853538ae/pydantic_ai_slim-1.80.0.tar.gz", hash = "sha256:034f7f910dfce5d82528c74a717a99065ae548390f0b906165972cd13a87d2cf", size = 549153, upload-time = "2026-04-10T23:31:19.862Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/14/4e850e54024b453ed905aa92b50b286ed9b096979e7d0896005be5e5b74c/pydantic_ai_slim-1.68.0-py3-none-any.whl", hash = "sha256:c3234c743ab256c7f26aecb2296428a55ae3db9f9ebb8d725941cae887e8e027", size = 567829, upload-time = "2026-03-13T03:39:00.91Z" },
+    { url = "https://files.pythonhosted.org/packages/23/bf/ef273265ef3530cf432fd6d0014ceed57d1cc5b1550fd975bc91152633c8/pydantic_ai_slim-1.80.0-py3-none-any.whl", hash = "sha256:160ad31f522c3d091f3ce32b478d26034c05b6c2c84798a4c8b191c7f9f94bee", size = 703157, upload-time = "2026-04-10T23:31:12Z" },
 ]
 
 [package.optional-dependencies]
@@ -2647,6 +2647,7 @@ cli = [
     { name = "argcomplete" },
     { name = "prompt-toolkit" },
     { name = "pyperclip" },
+    { name = "pyyaml" },
     { name = "rich" },
 ]
 cohere = [
@@ -2682,6 +2683,10 @@ openai = [
 ]
 retries = [
     { name = "tenacity" },
+]
+spec = [
+    { name = "pydantic-handlebars" },
+    { name = "pyyaml" },
 ]
 temporal = [
     { name = "temporalio" },
@@ -2796,7 +2801,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-evals"
-version = "1.68.0"
+version = "1.80.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2806,14 +2811,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/8f/cd2bb2cea3d0e5f108b2aa1c32ecaa5bd74c48feb403f6e945c48ca4eb8d/pydantic_evals-1.68.0.tar.gz", hash = "sha256:f0a3318f7b0e35d4d9c065e2dbf36cfd850387d0a894e23c55390061b4d9b8fe", size = 56693, upload-time = "2026-03-13T03:39:09.724Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/c3/49c0f1221321a56540b3fd7251a20d9e5a2de512f170afd9c6d08fe5b24c/pydantic_evals-1.80.0.tar.gz", hash = "sha256:03ee78212069638a9abe107997c02adbe7de01a2769c2a3aa1ae37e40c4f2b36", size = 65791, upload-time = "2026-04-10T23:31:21.321Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/53/eb1aaf65be91c866b13daae38b6c4cdcf92afc2225b9d1bd6eaeb8b42abf/pydantic_evals-1.68.0-py3-none-any.whl", hash = "sha256:5f0f9596ddf6ae82ac48f83c5e346351b0a8b333b29ff971b20522d37243e95b", size = 67603, upload-time = "2026-03-13T03:39:02.632Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/28/8480d2e53728a891e1157f6c741a7f2ec27da06b56936d5c6e1f64af0e51/pydantic_evals-1.80.0-py3-none-any.whl", hash = "sha256:1af302e312aa39a7fc20c14acfaea35283861d933a03473d43d858e3c07ac8ef", size = 77711, upload-time = "2026-04-10T23:31:13.937Z" },
 ]
 
 [[package]]
 name = "pydantic-graph"
-version = "1.68.0"
+version = "1.80.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2821,9 +2826,21 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/75/de53b774d7b96adc7a75ddc4cac4dfaea25d5538b5004710fc1e9a74180c/pydantic_graph-1.68.0.tar.gz", hash = "sha256:fa48d15659e9514393f0596f62a0355783309e725deedb14d8f3e68fccf3974a", size = 58534, upload-time = "2026-03-13T03:39:10.896Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/7b/03a8791e4916cb0f841fcd77ef6b6bf504419bf03d1c16e4ef80bfd553ad/pydantic_graph-1.80.0.tar.gz", hash = "sha256:94b8c2dd20730ce3cd0fa544ca9c31011a7bb0c5b9f5ca1dade6a6bed7719e8c", size = 59243, upload-time = "2026-04-10T23:31:22.504Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/bf/cd45f1987468679e8d631d1c0e6014c4156815440a985389bd11aeb4465f/pydantic_graph-1.68.0-py3-none-any.whl", hash = "sha256:a563291109c3efb69fe7553f20b164651fe98680252e8f07a3cd9a1db2f8a879", size = 72350, upload-time = "2026-03-13T03:39:04.439Z" },
+    { url = "https://files.pythonhosted.org/packages/38/12/483b7402d302021ff8537a746eebf018f4e0bb5892c7bef769ab968e03c1/pydantic_graph-1.80.0-py3-none-any.whl", hash = "sha256:60315c2042597d0377689ad48e9439760ec75d4ccda78830d2890ce9c94c6d84", size = 73065, upload-time = "2026-04-10T23:31:15.382Z" },
+]
+
+[[package]]
+name = "pydantic-handlebars"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/16/d41768bd3fd77e6250c20be11a3e68fee5fff07c3356455e6708f6a60f2a/pydantic_handlebars-0.1.0.tar.gz", hash = "sha256:1931c54946add1b5e3796c9bf6a005ed7662cef0109bb05c352f0b3d031a1260", size = 159826, upload-time = "2026-03-01T20:00:17.497Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5f/86b1630be61bdebf253c2f953a6c3f073ec21bb0725565ea3896802e1ca3/pydantic_handlebars-0.1.0-py3-none-any.whl", hash = "sha256:8a436fe8bc607295eb04bec58bd6e2c9498c9e069c557ff0b505e3d568c783bc", size = 40890, upload-time = "2026-03-01T20:00:16.106Z" },
 ]
 
 [[package]]
@@ -3508,7 +3525,7 @@ wheels = [
 
 [[package]]
 name = "temporalio"
-version = "1.20.0"
+version = "1.25.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nexus-rpc" },
@@ -3516,13 +3533,13 @@ dependencies = [
     { name = "types-protobuf" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/db/7d5118d28b0918888e1ec98f56f659fdb006351e06d95f30f4274962a76f/temporalio-1.20.0.tar.gz", hash = "sha256:5a6a85b7d298b7359bffa30025f7deac83c74ac095a4c6952fbf06c249a2a67c", size = 1850498, upload-time = "2025-11-25T21:25:20.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/9c/3782bab0bf11a40b550147c19a5d1a476c17405391751982408902d9f138/temporalio-1.25.0.tar.gz", hash = "sha256:a3bbec1dcc904f674402cfa4faae480fda490b1c53ea5440c1f1996c562016fb", size = 2152534, upload-time = "2026-04-08T18:53:55.388Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/1b/e69052aa6003eafe595529485d9c62d1382dd5e671108f1bddf544fb6032/temporalio-1.20.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:fba70314b4068f8b1994bddfa0e2ad742483f0ae714d2ef52e63013ccfd7042e", size = 12061638, upload-time = "2025-11-25T21:24:57.918Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/3b/3e8c67ed7f23bedfa231c6ac29a7a9c12b89881da7694732270f3ecd6b0c/temporalio-1.20.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:ffc5bb6cabc6ae67f0bfba44de6a9c121603134ae18784a2ff3a7f230ad99080", size = 11562603, upload-time = "2025-11-25T21:25:01.721Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/be/ed0cc11702210522a79e09703267ebeca06eb45832b873a58de3ca76b9d0/temporalio-1.20.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1e80c1e4cdf88fa8277177f563edc91466fe4dc13c0322f26e55c76b6a219e6", size = 11824016, upload-time = "2025-11-25T21:25:06.771Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/97/09c5cafabc80139d97338a2bdd8ec22e08817dfd2949ab3e5b73565006eb/temporalio-1.20.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba92d909188930860c9d89ca6d7a753bc5a67e4e9eac6cea351477c967355eed", size = 12189521, upload-time = "2025-11-25T21:25:12.091Z" },
-    { url = "https://files.pythonhosted.org/packages/11/23/5689c014a76aff3b744b3ee0d80815f63b1362637814f5fbb105244df09b/temporalio-1.20.0-cp310-abi3-win_amd64.whl", hash = "sha256:eacfd571b653e0a0f4aa6593f4d06fc628797898f0900d400e833a1f40cad03a", size = 12745027, upload-time = "2025-11-25T21:25:16.827Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e3/5676dd10d1164b6d6ca8752314054097b89c5da931e936af402a7b15236c/temporalio-1.25.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6dc1bc8e1773b1a833d86a7ede2dd90ef4e031ced5b748b59e7f09a5bf9b327d", size = 13943906, upload-time = "2026-04-08T18:53:30.022Z" },
+    { url = "https://files.pythonhosted.org/packages/89/50/7cbf7f845973be986ec165348f72f7a409750842a04d554965a39be5cb4f/temporalio-1.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:3c8fdcf79ea5ae8ae2cf6f48072e4a86c3e0f4778f6a8a066c6ff1d336587db4", size = 13298719, upload-time = "2026-04-08T18:53:35.95Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/31/d474bab8535552add6ed289911bf1ffae5d7071823ece1069842190fcaed/temporalio-1.25.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:141f37aaafd7d090ba5c8776e4e9bc60df1fbc64b9f50c8f00e905a436588ddc", size = 13555435, upload-time = "2026-04-08T18:53:41.36Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c8/e7dc053d6107bf2a037a3c9fe7b86639a25dcb888bde0e1ca366901ee47f/temporalio-1.25.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff7ca5bb80264976477d4dc7a839b3d22af8577ae92306526a061481db49bf92", size = 14052050, upload-time = "2026-04-08T18:53:46.44Z" },
+    { url = "https://files.pythonhosted.org/packages/08/70/9340ed3a578321cbc153041d34834bb1ec3f1f3e3d9cded47cd1b7c3e403/temporalio-1.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:9411534279a2e64847231b6059c214bff4d57cfd1532bd09f333d0b1603daa7f", size = 14299684, upload-time = "2026-04-08T18:53:52.482Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Wire StreamSink into PulseDeps; wrap graph run with open_stream()
- Stream thinking blocks via run_streaming() using run_stream_events()
- Add set_status() calls: Thinking/Planning/Working on/Wrapping up
- Persist plan todos via feelers.todos.create_todo + upsert_todo_list
- Pin todo card on creation, update on step completion, unpin on finish
- Add thinking config to FlickConfig (model_settings.thinking)
- Fix status: use 'completed' to match Slack feeler rendering
- Add NullStreamSink for tests; fallback to agent.run() for FunctionModel