### PR TITLE
feat(mcp): GitHub + Linear MCP toolsets with context-managed tentacle lifecycle

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,8 @@
       "request": "launch",
       "module": "uvicorn",
       "args": [
-        "main:app",
+        "main:create_app",
+        "--factory",
       ],
       "cwd": "${workspaceFolder}",
       "envFile": "${workspaceFolder}/.env",
@@ -27,7 +28,8 @@
       "request": "launch",
       "module": "uvicorn",
       "args": [
-        "main:app",
+        "main:create_app",
+        "--factory",
         "--reload",
         "--reload-dir",
         "octomate",

--- a/docs/plans/github-linear-mcp.md
+++ b/docs/plans/github-linear-mcp.md
@@ -11,7 +11,7 @@
 
 Give the inkling agent GitHub and Linear tools by connecting to each vendor's
 **official hosted MCP server** over Streamable HTTP, authenticated with **one
-operator-supplied token per integration** passed in the `Authorization` header.
+operator-supplied token per MCP server** passed in the `Authorization` header.
 No Docker, no npx, no subprocess, no callback server, no OAuth.
 
 Keep the model's tool list small with pydantic-ai's **built-in deferred
@@ -25,7 +25,8 @@ intent. No custom `load_skill`/`unload_skill` machinery.
   HTTP and accepts a PAT via `Authorization: Bearer <PAT>`; it also auto-hides
   tools the token lacks scope for.
 - **Linear** hosted MCP (`https://mcp.linear.app/mcp`) accepts a **personal API
-  key** in the `Authorization` header as an alternative to interactive OAuth.
+  key** (`lin_api_…`) via `Authorization: Bearer <key>` as an alternative to
+  interactive OAuth. (A raw, non-`Bearer` key is rejected with 401.)
 
 Both data sets already live on those platforms, so a hosted connection exposes
 nothing new. This honors "use my token, postpone OAuth" with the smallest
@@ -55,47 +56,47 @@ resolves. Deprecation warnings noted as a separate follow-up, not handled here:
 `AgentBuiltinTool`→`AgentNativeTool`, `agent.run(builtin_tools=/output_retries=)`,
 `pydantic_graph.Graph` (v2 removal), redundant `GoogleProvider(vertexai=False)`.
 
-### 2. Config — a new `integrations` section
+### 2. Config — a new `mcp` section
 
-New `octomate/config/integrations.py`:
+New `octomate/config/mcp.py`:
 
 ```python
-class GitHubIntegrationConfig(BaseModel):
+class GitHubMcpConfig(BaseModel):
     enabled: bool = False
     token: SecretStr | None = None
     url: str = "https://api.githubcopilot.com/mcp/"
     read_only: bool = False  # selects the /readonly endpoint variant
 
-class LinearIntegrationConfig(BaseModel):
+class LinearMcpConfig(BaseModel):
     enabled: bool = False
     token: SecretStr | None = None
     url: str = "https://mcp.linear.app/mcp"
 
-class IntegrationsConfig(BaseModel):
-    github: GitHubIntegrationConfig | None = None
-    linear: LinearIntegrationConfig | None = None
+class McpConfig(BaseModel):
+    github: GitHubMcpConfig | None = None
+    linear: LinearMcpConfig | None = None
 ```
 
-Wire `integrations: IntegrationsConfig` onto `OctomateConfig`
+Wire `mcp: McpConfig` onto `OctomateConfig`
 ([config/__init__.py](../../octomate/config/__init__.py)) and export the new
 models. Env follows the existing nested pattern:
-`OCTOMATE__INTEGRATIONS__GITHUB__TOKEN`, `OCTOMATE__INTEGRATIONS__LINEAR__TOKEN`.
+`OCTOMATE__MCP__GITHUB__TOKEN`, `OCTOMATE__MCP__LINEAR__TOKEN`.
 Add commented stubs to `octomate.default.yaml`.
 
 ### 3. Toolset builder
 
-New `octomate/tentacles/agent/inkling/integrations.py`:
+New `octomate/tentacles/agent/inkling/mcp.py`:
 
 ```python
-def build_integration_toolsets(
-    config: IntegrationsConfig,
+def build_mcp_toolsets(
+    config: McpConfig,
 ) -> list[AbstractToolset[None]]:
     toolsets = []
     if (gh := config.github) and gh.enabled:
         if gh.token is None:
-            raise ValueError("integrations.github.enabled but no token set")
+            raise ValueError("mcp.github.enabled but no token set")
         toolsets.append(
-            MCPServerStreamableHTTP(
+            MCPToolset(
                 gh.url,
                 headers={"Authorization": f"Bearer {gh.token.get_secret_value()}"},
                 id="github",
@@ -103,11 +104,11 @@ def build_integration_toolsets(
         )
     if (lin := config.linear) and lin.enabled:
         if lin.token is None:
-            raise ValueError("integrations.linear.enabled but no token set")
+            raise ValueError("mcp.linear.enabled but no token set")
         toolsets.append(
-            MCPServerStreamableHTTP(
+            MCPToolset(
                 lin.url,
-                headers={"Authorization": lin.token.get_secret_value()},
+                headers={"Authorization": f"Bearer {lin.token.get_secret_value()}"},
                 id="linear",
             ).defer_loading()
         )
@@ -121,36 +122,79 @@ Fail-fast on enabled-without-token (per AGENTS.md: no silent fallback).
 In [main.py](../../main.py), extend the agent's `toolsets`:
 
 ```python
-toolsets=[inkling_toolset, *build_integration_toolsets(config.integrations)],
+toolsets=[inkling_toolset, *build_mcp_toolsets(config.mcp)],
 ```
 
 `ToolSearch` is auto-injected — no capability change. The static
 `inkling_toolset` (e.g. `ask_questions`) stays eagerly loaded; only the MCP
 tools defer.
 
-### 5. Connection lifecycle — keep MCP warm
+### 5. Connection lifecycle — keep MCP warm via the tentacle context protocol
 
 The react graph calls `agent.run()` per node. Passing MCP servers as toolsets
 makes pydantic-ai enter/exit them per run unless the agent is already entered,
-which would reconnect + re-`initialize` the remote servers on every turn.
+which would reconnect + re-`initialize` the remote servers on every turn. The
+warm session must therefore outlive a single run and span the process lifetime.
 
-Enter the inkling agent once for the app's lifetime in the FastAPI lifespan
-([base.py:91](../../octomate/base.py#L91)): `async with agent:` (via
-`AsyncExitStack`) around the existing channel-activation block, so the warm MCP
-sessions live for the process and tear down on shutdown. The agent handle is
-reachable from the registered `InklingTentacle`. `cache_tools=True` (default)
-means the deferred corpus is fetched once and reused.
+**Make every tentacle an async context manager.** `Tentacle`
+([tentacles/base.py](../../octomate/tentacles/base.py)) now defines
+`__aenter__`/`__aexit__` (no-op defaults) in place of the old
+`activate()`/`deactivate()` pair, and the host just enters every tentacle. Each
+tentacle owns its own long-lived resources: agents hold warm MCP sessions,
+channels hold the inbound receive loop. This keeps `base.py`'s lifespan free of
+pydantic-ai *and* per-platform specifics.
+
+The `InklingTentacle` ([inkling/base.py](../../octomate/tentacles/agent/inkling/base.py))
+enters/exits its wrapped pydantic-ai agent via an `AsyncExitStack` it owns:
+
+```python
+async def __aenter__(self) -> Self:
+    # Entering the agent opens + `initialize`s every toolset's MCP session once;
+    # they stay warm until __aexit__.
+    await self._exit_stack.enter_async_context(self.agent)
+    return self
+
+async def __aexit__(self, *exc: object) -> None:
+    await self._exit_stack.aclose()
+```
+
+`cache_tools=True` (default) means the deferred corpus is fetched once and reused
+across runs. With no MCP toolsets configured the agent has nothing to open, so
+entering is a cheap no-op — agents that never declare MCP servers pay nothing.
+
+**Channels** do their setup/teardown directly in `__aenter__`/`__aexit__`. The
+`ChannelTentacle` base `__aenter__` resolves identity (`probe()`); each platform
+channel overrides it (calling `super().__aenter__()` first) to open its client and
+overrides `__aexit__` to close it. Most channels need no background task — Slack's
+SDK self-drives the socket, and Lark stays alive via its `_connect` + ping task —
+so their old `stop_event`/parking loop is gone. Only Napcat actively reads off the
+socket, so it spawns its reconnect loop as a background task in `__aenter__` and
+cancels/joins it in `__aexit__`. HTTP-driven channels (Vercel) inherit the base
+probe-only `__aenter__`.
+
+**Host wiring.** The lifespan in [base.py](../../octomate/base.py) is now just an
+`AsyncExitStack` entering every tentacle — agents first (warm tools before any
+channel ingests), then channels; teardown unwinds in reverse:
+
+```python
+async with AsyncExitStack() as stack:
+    for agent in self.agents.values():
+        await stack.enter_async_context(agent)
+    for channel in self.channels.values():
+        await stack.enter_async_context(channel)
+    yield
+```
 
 ### 6. `octomate.default.yaml`
 
 ```yaml
-# integrations:
+# mcp:
 #   github:
 #     enabled: true
-#     token: ghp_xxx            # or OCTOMATE__INTEGRATIONS__GITHUB__TOKEN
+#     token: ghp_xxx            # or OCTOMATE__MCP__GITHUB__TOKEN
 #   linear:
 #     enabled: true
-#     token: lin_api_xxx        # or OCTOMATE__INTEGRATIONS__LINEAR__TOKEN
+#     token: lin_api_xxx        # or OCTOMATE__MCP__LINEAR__TOKEN
 ```
 
 ## Decisions settled
@@ -161,14 +205,20 @@ means the deferred corpus is fetched once and reused.
   delegation is deferred with the identity work.
 - **Built-in `defer_loading()` + `ToolSearch`, not a custom skill gate.** The old
   plan's `load_skill`/`unload_skill` meta-tools are unnecessary in 1.107.
-- **`integrations` config section**, parallel to `channels`/`providers`.
+- **`mcp` config section**, parallel to `channels`/`providers`.
+- **MCP lifecycle owned by the agent tentacle** via the async-context protocol
+  (`__aenter__`/`__aexit__`), not the FastAPI lifespan. The host just enters every
+  tentacle; the tentacle warms its sessions.
+- **Per-vendor tool-name prefixes** (`github_…`, `linear_…`) via `.prefixed()`.
+  Required, not optional: both servers expose `list_issues`, which pydantic-ai
+  rejects as a collision when combined. Applied before `.defer_loading()`.
 
 ## Verification
 
 1. `uv run pytest` stays green (already true post-bump).
-2. Config: `integrations.github.enabled=true` with token parses; enabled without
+2. Config: `mcp.github.enabled=true` with token parses; enabled without
    token raises at builder time.
-3. Builder: returns a deferred toolset only for enabled integrations; disabled →
+3. Builder: returns a deferred toolset only for enabled servers; disabled →
    empty list.
 4. Unit (TestModel/FunctionModel): with a deferred toolset wired, a run can call
    the injected `search_tools`, then a discovered tool resolves through the react
@@ -178,13 +228,75 @@ means the deferred corpus is fetched once and reused.
    "list my GitHub issues" / "show my Linear issues" triggers tool search →
    discovered tool call → result. Confirm tools are absent from the model's
    initial tool list until searched.
-6. Shutdown: MCP sessions close cleanly with the lifespan.
+6. Lifecycle: entering the `InklingTentacle` (`async with`) opens the MCP
+   sessions once and exiting closes them cleanly (assert the host lifespan
+   enters every tentacle, and that a disabled-MCP agent enters as a no-op).
+   Napcat's `__aenter__` spawns its reconnect loop as a background task that
+   `__aexit__` cancels and joins.
+
+## Future thinking — dynamic MCP install (NOT this run's scope)
+
+This run hard-codes two typed servers (`github`, `linear`) behind static config.
+The question worth parking: **how could a user/admin add or install MCP servers at
+runtime without a code change?** Sketching the option space, cheapest first — the
+agent-tentacle lifecycle from §5 is what makes the harder options tractable,
+because "warm a server" and "tear one down" are already first-class operations the
+tentacle owns.
+
+- **A. Generic server map in config (smallest real step).** Replace the two typed
+  fields with `servers: dict[str, McpServerConfig]`, where `McpServerConfig` is a
+  discriminated union on transport (`streamable_http` remote vs `stdio` local
+  Docker/npx). The two named servers become two entries. Adding a server = editing
+  yaml/env + restart; no code. `github`/`linear` keep convenience subclasses with
+  baked-in `url` defaults. Honest limit: still restart-based, still operator-edited
+  files. Good migration target even within the static design.
+
+- **B. Persisted registry + admin API (true runtime add).** Store `McpServerConfig`
+  rows via Arcanus (schema/transmuter, with the secret as a reference into a
+  secrets store, never plaintext). An admin-only FastAPI router (owned by the
+  Octomate instance per the architecture rules, not a channel) does
+  CRUD. On create: build the toolset → `.defer_loading()` → `enter_async_context`
+  it into the *live* agent tentacle's `AsyncExitStack` → it's immediately
+  discoverable via `ToolSearch`, no restart. On delete: pop/close that one stack
+  entry. The hot-attach hinges on §5's design: the tentacle already owns the stack
+  and the warm-session contract, so "add server N+1" is one more
+  `enter_async_context`. The real work is a *mutable composite toolset* the agent
+  reads through, so the model picks up additions without rebuilding the `Agent`.
+
+- **C. Catalog / marketplace install (B + identity).** Admin browses a curated
+  catalog (à la Claude connectors), picks a server, supplies a token or runs OAuth,
+  spec is stored encrypted and attached as in B. This is where the parked per-user
+  OAuth + identity/profile work re-enters: per-user installs mean the
+  `Authorization` header is resolved per run off `InklingDeps`/identity, and the
+  warm-session model from §5 may need per-principal session pools rather than one
+  process-wide session. Largest surface; depends on the identity layer landing
+  first.
+
+- **D. Per-run / per-conversation toolsets (dynamic but cold).** `run()` already
+  accepts `toolsets=`, so a server could be attached for a single conversation
+  without touching the warm set. Cheap to reason about, but reconnects +
+  `initialize`s per run (the exact cost §5 avoids) — fine for one-off/scoped use,
+  wrong for anything hot-path.
+
+Cross-cutting concerns any of B–D must answer before they're safe:
+
+- **Trust & isolation.** Arbitrary MCP install is an SSRF / prompt-injection /
+  tool-shadowing vector (a malicious server can mimic a trusted tool name).
+  Minimum: admin-gated installs, a URL/host allowlist, and collision detection on
+  tool names surfaced through `ToolSearch` (ties into the prefix/rename item below).
+- **Secret handling.** Tokens must live in a secrets store with references in the
+  DB, scrubbed from logs/logfire the same way channel creds are today.
+- **Failure modes.** A dead/slow server must fail its own `activate()` without
+  taking down the agent or the host — per-server try/scope, not one shared stack
+  that aborts on the first bad entry.
+
+Recommendation when this is picked up: **A now-ish** (mechanical, low risk, sets the
+data shape), then **B** as the first real "install at runtime" milestone, with **C**
+folded into the identity epic.
 
 ## Out of scope (later)
 
 - Per-user tokens / OAuth / central identity + profile system (parked).
 - Read-only enforcement beyond GitHub's `read_only` endpoint variant.
-- Tool-prefix/rename to disambiguate if GitHub and Linear ever collide on a name
-  (none known today; revisit if `ToolSearch` surfaces a clash).
 - Deprecation cleanup from the 1.107 bump.
 - Additional skills (the README's Pixiv/QWeather/Tarot etc.).

--- a/main.py
+++ b/main.py
@@ -15,7 +15,11 @@ from octomate.capabilities.todos import TodoCapability
 from octomate.config import OctomateConfig
 from octomate.providers import ProviderRegistry
 from octomate.schemas.segments import MessageSegment
-from octomate.tentacles.agent.inkling import InklingTentacle, inkling_toolset
+from octomate.tentacles.agent.inkling import (
+    InklingTentacle,
+    build_mcp_toolsets,
+    inkling_toolset,
+)
 from octomate.tentacles.agent.inkling.prompts import SYSTEM_PROMPT
 from octomate.tentacles.channel.lark import LarkTentacle
 from octomate.tentacles.channel.napcat import NapcatTentacle
@@ -74,7 +78,10 @@ def create_app() -> FastAPI:
         deps_type=type(None),
         name="octomate-inkling",
         output_type=[str, list[MessageSegment], DeferredToolRequests],
-        toolsets=[inkling_toolset],
+        toolsets=[
+            inkling_toolset,
+            *build_mcp_toolsets(config.mcp),
+        ],
         capabilities=[
             TodoCapability(),
             SendCapability(),

--- a/octomate.default.yaml
+++ b/octomate.default.yaml
@@ -76,6 +76,19 @@ octomate:
   #     # or: profile_name: my-profile
   #     # or: api_key: <AWS_BEARER_TOKEN_BEDROCK>
 
+  # Vendor MCP servers (GitHub, Linear) connected over Streamable HTTP with one
+  # operator token each. Tools are deferred-loaded: hidden until the model
+  # discovers them via ToolSearch. Put real tokens in octomate.yaml or env.
+  mcp: {}
+  # mcp:
+  #   github:
+  #     enabled: true
+  #     token: ghp_xxx            # or OCTOMATE__MCP__GITHUB__TOKEN
+  #     read_only: false          # true => the /readonly endpoint variant
+  #   linear:
+  #     enabled: true
+  #     token: lin_api_xxx        # or OCTOMATE__MCP__LINEAR__TOKEN
+
 # Live-replay test targets (`pytest tests/trigger/`).
 # This section sits OUTSIDE `octomate:` — the application never reads it.
 # Configure it in the gitignored octomate.yaml, next to the channel credentials:

--- a/octomate/__init__.py
+++ b/octomate/__init__.py
@@ -1,3 +1,13 @@
-from octomate.base import Octomate
+import warnings
+
+from pydantic_graph import PydanticGraphDeprecationWarning
+
+# The react/triage graphs intentionally use pydantic-graph's deprecated v1 BaseNode
+# `Graph` API (pinned <2 in pyproject) until the v2 GraphBuilder API is stable;
+# silence its import-time deprecation warning. Set here, before any octomate
+# submodule imports `Graph`, so it covers every entrypoint (app and tests).
+warnings.filterwarnings("ignore", category=PydanticGraphDeprecationWarning)
+
+from octomate.base import Octomate  # noqa: E402  (filter must precede this import)
 
 __all__ = ["Octomate"]

--- a/octomate/base.py
+++ b/octomate/base.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import logging
 from collections.abc import Awaitable, Callable
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass, field
 
-import anyio
 import logfire
 from fastapi import APIRouter, FastAPI, Request, Response
 
@@ -25,8 +23,6 @@ from octomate.tentacles.agent.inkling.graph import (
     triage_graph,
 )
 from octomate.tentacles.channel.base import ChannelTentacle
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -91,23 +87,17 @@ class Octomate:
         @asynccontextmanager
         async def lifespan(app: FastAPI):
             with sqlalchemy_materia():
-                for channel in self.channels.values():
-                    await channel.probe()
-                async with anyio.create_task_group() as tg:
+                # Each tentacle is an async context manager owning its own
+                # long-lived resources (agents: warm MCP sessions; channels:
+                # the inbound receive loop). Enter agents first so their tools
+                # are warm before channels start ingesting; the stack tears
+                # everything down in reverse on shutdown.
+                async with AsyncExitStack() as stack:
+                    for agent in self.agents.values():
+                        await stack.enter_async_context(agent)
                     for channel in self.channels.values():
-                        tg.start_soon(channel.activate)
-                    try:
-                        yield
-                    finally:
-                        for channel in reversed(list(self.channels.values())):
-                            try:
-                                await channel.deactivate()
-                            except Exception:
-                                logger.exception(
-                                    "Channel %s failed during shutdown",
-                                    getattr(channel, "id", "<unknown>"),
-                                )
-                        tg.cancel_scope.cancel()
+                        await stack.enter_async_context(channel)
+                    yield
 
         app = FastAPI(title=title, docs_url="/docs", redoc_url=None, lifespan=lifespan)
         app.state.octomate = self

--- a/octomate/config/__init__.py
+++ b/octomate/config/__init__.py
@@ -23,6 +23,7 @@ from octomate.config.channels import (
     SlackChannelConfig,
     SlackStreamConfig,
 )
+from octomate.config.mcp import GitHubMcpConfig, LinearMcpConfig, McpConfig
 from octomate.config.models import (
     AnthropicModelSettings,
     BedrockModelSettings,
@@ -45,7 +46,7 @@ from octomate.config.providers import (
 
 class OctomateConfig(BaseSettings):
     model_config = SettingsConfigDict(
-        env_prefix="OCTOMATE_",
+        env_prefix="OCTOMATE__",
         env_nested_delimiter="__",
         yaml_file=("octomate.default.yaml", "octomate.yaml"),
         yaml_config_section="octomate",
@@ -61,6 +62,7 @@ class OctomateConfig(BaseSettings):
     logfire: LogfireConfig = Field(default_factory=LogfireConfig)
     channels: ChannelsConfig = Field(default_factory=ChannelsConfig)
     providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
+    mcp: McpConfig = Field(default_factory=McpConfig)
 
     @classmethod
     def settings_customise_sources(
@@ -101,6 +103,10 @@ __all__ = [
     "OpenAIProviderConfig",
     "ProvidersConfig",
     "VertexProviderConfig",
+    # mcp
+    "McpConfig",
+    "GitHubMcpConfig",
+    "LinearMcpConfig",
     # channels
     "ChannelConfig",
     "ChannelsConfig",

--- a/octomate/config/mcp.py
+++ b/octomate/config/mcp.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, SecretStr
+
+
+class GitHubMcpConfig(BaseModel):
+    enabled: bool = False
+    token: SecretStr | None = None
+    url: str = "https://api.githubcopilot.com/mcp/"
+    read_only: bool = False
+
+
+class LinearMcpConfig(BaseModel):
+    enabled: bool = False
+    token: SecretStr | None = None
+    url: str = "https://mcp.linear.app/mcp"
+
+
+class McpConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    github: GitHubMcpConfig | None = None
+    linear: LinearMcpConfig | None = None

--- a/octomate/tentacles/agent/inkling/__init__.py
+++ b/octomate/tentacles/agent/inkling/__init__.py
@@ -1,7 +1,9 @@
 from octomate.tentacles.agent.inkling.base import InklingTentacle
+from octomate.tentacles.agent.inkling.mcp import build_mcp_toolsets
 from octomate.tentacles.agent.inkling.tools import inkling_toolset
 
 __all__ = [
     "InklingTentacle",
+    "build_mcp_toolsets",
     "inkling_toolset",
 ]

--- a/octomate/tentacles/agent/inkling/base.py
+++ b/octomate/tentacles/agent/inkling/base.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator, Sequence
+from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, TypeAlias, overload
+from typing import TYPE_CHECKING, Self, TypeAlias, overload
 
 import logfire
 from pydantic_ai import (
-    AgentNativeTool,
     AgentCapability,
     AgentModelSettings,
+    AgentNativeTool,
     AgentRunResult,
     AgentRunResultEvent,
     RunUsage,
@@ -26,13 +27,6 @@ from pydantic_ai.output import OutputSpec
 from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults
 from pydantic_ai.toolsets import AbstractToolset
 
-from octomate.managers.conversations import ConversationManager
-from octomate.schemas.conversation import ConversationKey
-from octomate.schemas.segments import MessageSegment
-from octomate.tentacles.agent.base import (
-    AgentSpecInput,
-    AgentTentacle,
-)
 from octomate.capabilities.agent import Agent
 from octomate.capabilities.deferred import DeferredResolver, DeferredSuspender
 from octomate.capabilities.react import (
@@ -43,6 +37,13 @@ from octomate.capabilities.react import (
     ResumeTurn,
     StartTurn,
     iter_react_graph_events,
+)
+from octomate.managers.conversations import ConversationManager
+from octomate.schemas.conversation import ConversationKey
+from octomate.schemas.segments import MessageSegment
+from octomate.tentacles.agent.base import (
+    AgentSpecInput,
+    AgentTentacle,
 )
 
 if TYPE_CHECKING:
@@ -59,6 +60,8 @@ class InklingTentacle(AgentTentacle[InklingOutput, None]):
     conversation_manager: ConversationManager = field(init=False)
     deferred_resolver: DeferredResolver | None = None
 
+    _exit_stack: AsyncExitStack = field(init=False)
+
     def __init__(
         self,
         id: str,
@@ -72,6 +75,17 @@ class InklingTentacle(AgentTentacle[InklingOutput, None]):
         self.agent = agent
         self.conversation_manager = conversation_manager or ConversationManager()
         self.deferred_resolver = deferred_resolver
+        self._exit_stack = AsyncExitStack()
+
+    async def __aenter__(self) -> Self:
+        # Enter the wrapped pydantic-ai agent once for the tentacle's lifetime so
+        # its MCP toolsets open + `initialize` a single warm session, reused across
+        # every react-graph run instead of reconnecting per turn.
+        await self._exit_stack.enter_async_context(self.agent)
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self._exit_stack.aclose()
 
     @overload
     async def run(

--- a/octomate/tentacles/agent/inkling/mcp.py
+++ b/octomate/tentacles/agent/inkling/mcp.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pydantic_ai.mcp import MCPToolset
+from pydantic_ai.toolsets import AbstractToolset
+
+from octomate.config import McpConfig
+
+
+def build_mcp_toolsets(config: McpConfig) -> list[AbstractToolset[None]]:
+    """Build deferred-loading MCP toolsets for each enabled vendor server.
+
+    Each server is connected over Streamable HTTP (the default transport for an
+    HTTP URL) with the operator token in the `Authorization` header. Tool names
+    are prefixed per vendor (`github_…`, `linear_…`) so the two servers can't
+    collide (e.g. both expose `list_issues`), and `.defer_loading()` keeps them
+    hidden from the model until discovered through the auto-injected ToolSearch.
+    """
+    toolsets: list[AbstractToolset[None]] = []
+
+    if (gh := config.github) and gh.enabled:
+        if gh.token is None:
+            raise ValueError("mcp.github.enabled but no token set")
+        url = gh.url.rstrip("/") + "/readonly" if gh.read_only else gh.url
+        toolsets.append(
+            MCPToolset(
+                url,
+                headers={"Authorization": f"Bearer {gh.token.get_secret_value()}"},
+                id="github",
+            )
+            .prefixed("github")
+            .defer_loading()
+        )
+
+    if (lin := config.linear) and lin.enabled:
+        if lin.token is None:
+            raise ValueError("mcp.linear.enabled but no token set")
+        toolsets.append(
+            MCPToolset(
+                lin.url,
+                headers={"Authorization": f"Bearer {lin.token.get_secret_value()}"},
+                id="linear",
+            )
+            .prefixed("linear")
+            .defer_loading()
+        )
+
+    return toolsets

--- a/octomate/tentacles/base.py
+++ b/octomate/tentacles/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, Self, TypeVar
 
 if TYPE_CHECKING:
     from octomate.base import Octomate
@@ -17,13 +17,18 @@ class Tentacle(Generic[TentaclePrimaryT, TentacleSecondaryT]):
     A tentacle is a lifecycle component, not a message dispatcher. Channel
     tentacles receive platform events and call Octomate.awake; agent tentacles
     expose pydantic-ai-style run methods.
+
+    A tentacle is an async context manager: the host enters it to start the
+    tentacle's long-lived resources and exits it to tear them down. The base
+    implementation is a no-op; subclasses override `__aenter__`/`__aexit__`.
     """
 
     id: str
     octomate: Octomate = field(repr=False)
 
-    async def activate(self) -> None:
-        """Start any long-lived platform client owned by the tentacle."""
+    async def __aenter__(self) -> Self:
+        """Start any long-lived platform resources owned by the tentacle."""
+        return self
 
-    async def deactivate(self) -> None:
-        """Stop any long-lived platform client owned by the tentacle."""
+    async def __aexit__(self, *exc: object) -> None:
+        """Stop any long-lived platform resources owned by the tentacle."""

--- a/octomate/tentacles/channel/base.py
+++ b/octomate/tentacles/channel/base.py
@@ -13,7 +13,15 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar, Generic, Literal, TypeAlias, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    ClassVar,
+    Generic,
+    Literal,
+    Self,
+    TypeAlias,
+    TypeVar,
+)
 
 import anyio
 import logfire
@@ -174,7 +182,7 @@ class ChannelTentacle(
 
     async def probe(self) -> None:
         """Resolve the channel's own identity from the platform. Awaited by the
-        host before the channel is activated, so `self.profile` is set before any
+        host before the channel is served, so `self.profile` is set before any
         inbound event is ingested."""
         self.profile = await self.ink.inspect()
         logger.info(
@@ -183,6 +191,13 @@ class ChannelTentacle(
             self.profile.user_id,
             self.profile.name,
         )
+
+    async def __aenter__(self) -> Self:
+        # Resolve identity before any inbound event is ingested. Channels with a
+        # persistent connection override this to open it (and `__aexit__` to tear
+        # it down); HTTP-driven channels (e.g. the dev UI) need only the probe.
+        await self.probe()
+        return self
 
     @property
     def name(self) -> str:

--- a/octomate/tentacles/channel/lark/base.py
+++ b/octomate/tentacles/channel/lark/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import replace
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Self
 
 import lark_oapi
 import lark_oapi.ws.client as ws_mod
@@ -75,7 +75,6 @@ class LarkTentacle(ChannelTentacle[P2ImMessageReceiveV1, LarkOutboundMessage]):
     chromo: LarkChromo
 
     ws_client: lark_oapi.ws.Client
-    stop_event: asyncio.Event | None
     ping_task: asyncio.Task[None] | None
 
     def __init__(
@@ -105,7 +104,6 @@ class LarkTentacle(ChannelTentacle[P2ImMessageReceiveV1, LarkOutboundMessage]):
             event_handler=event_handler,
             log_level=lark_oapi.LogLevel.INFO,
         )
-        self.stop_event = None
         self.ping_task = None
         markdown_feeler = LarkMarkdownFeeler(ink=self.ink, chromo=self.chromo)
         approvals = LarkApprovalFeeler(self.ink)
@@ -125,24 +123,29 @@ class LarkTentacle(ChannelTentacle[P2ImMessageReceiveV1, LarkOutboundMessage]):
             ask_questions=ask_questions,
         )
 
-    async def activate(self) -> None:
+    async def __aenter__(self) -> Self:
+        await super().__aenter__()
         logger.info("Channel %s: starting Lark WebSocket client", self.id)
         # lark-oapi exposes a blocking public start(), but its WebSocket client
         # is async internally. Run those internals on Octomate's event loop so
-        # message callbacks can schedule ingest directly.
+        # message callbacks can schedule ingest directly. `_connect` plus the ping
+        # task keep the socket live and callback-driven — no receive loop to park.
         ws_mod.loop = asyncio.get_running_loop()
-        self.stop_event = asyncio.Event()
         await self.ws_client._connect()  # type: ignore[attr-defined]
         self.ping_task = asyncio.create_task(self.ws_client._ping_loop())  # type: ignore[attr-defined]
-        try:
-            await self.stop_event.wait()
-        finally:
-            await self._disconnect()
+        return self
 
-    async def deactivate(self) -> None:
-        if self.stop_event is not None:
-            self.stop_event.set()
-        await self._disconnect()
+    async def __aexit__(self, *exc: object) -> None:
+        self.ws_client._auto_reconnect = False  # type: ignore[attr-defined]
+        if self.ping_task is not None:
+            ping_task = self.ping_task
+            self.ping_task = None
+            ping_task.cancel()
+            try:
+                await ping_task
+            except asyncio.CancelledError:
+                pass
+        await self.ws_client._disconnect()  # type: ignore[attr-defined]
 
     async def start_sub_thread(
         self,
@@ -313,19 +316,3 @@ class LarkTentacle(ChannelTentacle[P2ImMessageReceiveV1, LarkOutboundMessage]):
             )
 
         return P2CardActionTriggerResponse({})
-
-    async def close(self) -> None:
-        await self.deactivate()
-        self.ink.close()
-
-    async def _disconnect(self) -> None:
-        self.ws_client._auto_reconnect = False  # type: ignore[attr-defined]
-        if self.ping_task is not None:
-            ping_task = self.ping_task
-            self.ping_task = None
-            ping_task.cancel()
-            try:
-                await ping_task
-            except asyncio.CancelledError:
-                pass
-        await self.ws_client._disconnect()  # type: ignore[attr-defined]

--- a/octomate/tentacles/channel/napcat/base.py
+++ b/octomate/tentacles/channel/napcat/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 from pydantic import SecretStr
 from websockets.asyncio.client import ClientConnection, connect
@@ -24,6 +24,7 @@ class NapcatTentacle(ChannelTentacle[str | bytes, NapcatOutboundMessage]):
     ws_url: str
     ws_client: ClientConnection | None
     stop_event: asyncio.Event | None
+    serve_task: asyncio.Task[None] | None
 
     access_token: SecretStr | None
     backoff_base: float
@@ -57,8 +58,30 @@ class NapcatTentacle(ChannelTentacle[str | bytes, NapcatOutboundMessage]):
         self.backoff_factor = config.backoff_factor
         self.ws_client = None
         self.stop_event = None
+        self.serve_task = None
 
-    async def activate(self) -> None:
+    async def __aenter__(self) -> Self:
+        await super().__aenter__()
+        # Napcat reads messages off the socket itself (`sense`), so the reconnect
+        # loop must run as a background task the tentacle owns.
+        self.serve_task = asyncio.create_task(self.serve(), name=f"napcat:{self.id}")
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        if self.stop_event is not None:
+            self.stop_event.set()
+        if self.ws_client is not None:
+            await self.ws_client.close()
+            self.ws_client = None
+        if self.serve_task is not None:
+            self.serve_task.cancel()
+            try:
+                await self.serve_task
+            except asyncio.CancelledError:
+                pass
+            self.serve_task = None
+
+    async def serve(self) -> None:
         logger.info("Channel %s: connecting to Napcat at %s", self.id, self.ws_url)
         self.stop_event = asyncio.Event()
         delay = self.backoff_base
@@ -104,17 +127,6 @@ class NapcatTentacle(ChannelTentacle[str | bytes, NapcatOutboundMessage]):
                 pass
             delay = min(delay * self.backoff_factor, self.backoff_max)
 
-    async def deactivate(self) -> None:
-        if self.stop_event is not None:
-            self.stop_event.set()
-        if self.ws_client is not None:
-            await self.ws_client.close()
-            self.ws_client = None
-
     async def sense(self, ws: ClientConnection) -> None:
         async for raw in ws:
             await self.ingest(raw)
-
-    async def close(self) -> None:
-        await self.deactivate()
-        await self.ink.close()

--- a/octomate/tentacles/channel/slack/base.py
+++ b/octomate/tentacles/channel/slack/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import replace
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Self
 
 from pydantic import TypeAdapter, ValidationError
 from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
@@ -124,15 +124,19 @@ class SlackTentacle(ChannelTentacle[SlackMessageEvent, SlackOutboundMessage]):
             ask_questions=ask_questions,
         )
 
-    async def activate(self) -> None:
+    async def __aenter__(self) -> Self:
+        await super().__aenter__()
         logger.info("Channel %s: starting Slack Socket Mode client", self.id)
         self.handler = AsyncSocketModeHandler(
             self.app,
             self.app_token.get_secret_value(),
         )
+        # start_async returns once connected; the Slack SDK drives the socket on
+        # its own background tasks, so there is nothing to keep alive here.
         await self.handler.start_async()
+        return self
 
-    async def deactivate(self) -> None:
+    async def __aexit__(self, *exc: object) -> None:
         if self.handler:
             await self.handler.close_async()
             self.handler = None

--- a/tests/agent/test_mcp.py
+++ b/tests/agent/test_mcp.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastmcp.client.transports import StreamableHttpTransport
+from pydantic import SecretStr
+from pydantic_ai.mcp import MCPToolset
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.tools import DeferredToolRequests
+from pydantic_ai.toolsets import (
+    AbstractToolset,
+    DeferredLoadingToolset,
+    FunctionToolset,
+    PrefixedToolset,
+)
+
+from octomate import Octomate
+from octomate.capabilities.agent import Agent
+from octomate.config import GitHubMcpConfig, LinearMcpConfig, McpConfig
+from octomate.schemas.segments import MessageSegment
+from octomate.tentacles.agent.inkling import InklingTentacle, build_mcp_toolsets
+from octomate.tentacles.agent.inkling.base import InklingOutput
+
+
+def _prefixed(toolset: AbstractToolset[None]) -> PrefixedToolset[None]:
+    # Each server is wrapped DeferredLoadingToolset -> PrefixedToolset -> MCPToolset.
+    assert isinstance(toolset, DeferredLoadingToolset)
+    prefixed = toolset.wrapped
+    assert isinstance(prefixed, PrefixedToolset)
+    return prefixed
+
+
+def _toolset(toolset: AbstractToolset[None]) -> MCPToolset:
+    inner = _prefixed(toolset).wrapped
+    assert isinstance(inner, MCPToolset)
+    return inner
+
+
+def _transport(toolset: AbstractToolset[None]) -> StreamableHttpTransport:
+    transport = _toolset(toolset).client.transport
+    assert isinstance(transport, StreamableHttpTransport)
+    return transport
+
+
+def test_no_servers_returns_empty() -> None:
+    assert build_mcp_toolsets(McpConfig()) == []
+
+
+def test_disabled_server_is_skipped() -> None:
+    config = McpConfig(github=GitHubMcpConfig(enabled=False, token=SecretStr("ghp_x")))
+    assert build_mcp_toolsets(config) == []
+
+
+def test_enabled_without_token_fails_fast() -> None:
+    config = McpConfig(github=GitHubMcpConfig(enabled=True))
+    with pytest.raises(ValueError, match="mcp.github.enabled but no token set"):
+        build_mcp_toolsets(config)
+
+
+def test_github_toolset_is_deferred_with_bearer_header() -> None:
+    config = McpConfig(github=GitHubMcpConfig(enabled=True, token=SecretStr("ghp_x")))
+
+    (toolset,) = build_mcp_toolsets(config)
+
+    assert _toolset(toolset).id == "github"
+    assert _prefixed(toolset).prefix == "github"
+    transport = _transport(toolset)
+    assert transport.url == "https://api.githubcopilot.com/mcp/"
+    assert transport.headers == {"Authorization": "Bearer ghp_x"}
+
+
+def test_github_read_only_selects_readonly_endpoint() -> None:
+    config = McpConfig(
+        github=GitHubMcpConfig(enabled=True, token=SecretStr("ghp_x"), read_only=True)
+    )
+
+    (toolset,) = build_mcp_toolsets(config)
+
+    assert _transport(toolset).url == "https://api.githubcopilot.com/mcp/readonly"
+
+
+def test_linear_toolset_uses_bearer_authorization_header() -> None:
+    config = McpConfig(linear=LinearMcpConfig(enabled=True, token=SecretStr("lin_x")))
+
+    (toolset,) = build_mcp_toolsets(config)
+
+    assert _toolset(toolset).id == "linear"
+    assert _prefixed(toolset).prefix == "linear"
+    assert _transport(toolset).headers == {"Authorization": "Bearer lin_x"}
+
+
+def test_both_servers_build_in_order() -> None:
+    config = McpConfig(
+        github=GitHubMcpConfig(enabled=True, token=SecretStr("ghp_x")),
+        linear=LinearMcpConfig(enabled=True, token=SecretStr("lin_x")),
+    )
+
+    toolsets = build_mcp_toolsets(config)
+
+    assert [_toolset(ts).id for ts in toolsets] == ["github", "linear"]
+
+
+class SpyToolset(FunctionToolset[None]):
+    """Counts how many times the agent enters/exits it, standing in for an MCP
+    server's warm session without a real connection."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.entered = 0
+        self.exited = 0
+
+    async def __aenter__(self) -> SpyToolset:
+        self.entered += 1
+        return self
+
+    async def __aexit__(self, *args: Any) -> bool | None:
+        self.exited += 1
+        return None
+
+
+def _tentacle_with(toolset: AbstractToolset[None]) -> InklingTentacle:
+    octomate = Octomate()
+    agent: Agent[None, InklingOutput] = Agent(
+        TestModel(),
+        deps_type=type(None),
+        name="octomate-inkling",
+        output_type=[str, list[MessageSegment], DeferredToolRequests],
+        toolsets=[toolset],
+    )
+    return InklingTentacle("inkling", octomate, agent=agent)
+
+
+async def test_entering_tentacle_enters_agent_toolsets_once() -> None:
+    spy = SpyToolset()
+    tentacle = _tentacle_with(spy)
+
+    async with tentacle:
+        assert (spy.entered, spy.exited) == (1, 0)
+
+    assert (spy.entered, spy.exited) == (1, 1)

--- a/tests/channels/napcat/test_ink.py
+++ b/tests/channels/napcat/test_ink.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 from collections.abc import AsyncIterator
 from types import SimpleNamespace, TracebackType
@@ -176,11 +177,40 @@ async def test_napcat_tentacle_connects_with_auth_header(monkeypatch) -> None:
         FakeConnect,
     )
 
-    await channel.activate()
+    await channel.serve()
 
     assert calls == [
         ("ws://napcat", {"Authorization": "Bearer token"}),
     ]
+
+
+async def test_napcat_context_manager_runs_serve_until_exit(monkeypatch) -> None:
+    channel = object.__new__(NapcatTentacle)
+    channel.id = "napcat"
+    channel.ws_client = None
+    channel.stop_event = None
+    channel.serve_task = None
+
+    started = asyncio.Event()
+    blocked = asyncio.Event()
+
+    async def fake_probe() -> None:
+        return None
+
+    async def fake_serve() -> None:
+        started.set()
+        await blocked.wait()
+
+    monkeypatch.setattr(channel, "probe", fake_probe)
+    monkeypatch.setattr(channel, "serve", fake_serve)
+
+    async with channel:
+        await asyncio.wait_for(started.wait(), timeout=1)
+        assert channel.serve_task is not None
+        assert not channel.serve_task.done()
+
+    # __aexit__ cancels and joins the never-completing serve loop.
+    assert channel.serve_task is None
 
 
 async def test_napcat_consume_renders_plain_answer_via_default_timeline() -> None:

--- a/tests/channels/test_base.py
+++ b/tests/channels/test_base.py
@@ -536,3 +536,22 @@ async def test_start_sub_thread_falls_back_to_main_target(
     assert "does not support sub-thread startup" in caplog.text
     assert len(channel.sent) == 1
     assert channel.sent[0][2][0]["text"] == "handoff"
+
+
+async def test_channel_context_manager_probes_on_enter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = FakeChannelTentacle(id="chan1")
+    probed: list[bool] = []
+    original = channel.probe
+
+    async def probe() -> None:
+        probed.append(True)
+        await original()
+
+    monkeypatch.setattr(channel, "probe", probe)
+
+    async with channel as entered:
+        assert entered is channel
+
+    assert probed == [True]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,10 @@ from pydantic_settings import SettingsConfigDict
 
 from octomate.config import (
     ChannelsConfig,
+    GitHubMcpConfig,
     LarkChannelConfig,
+    LinearMcpConfig,
+    McpConfig,
     NapcatChannelConfig,
     OctomateConfig,
     SlackChannelConfig,
@@ -67,6 +70,42 @@ def test_channel_config_parses_supported_channels() -> None:
     assert config.channels.lark.stream.flush_interval == 0.2
     assert config.channels.lark.stream.min_chars == 1
     assert config.channels.napcat.stream.enabled is False
+
+
+def test_mcp_defaults_to_no_servers() -> None:
+    mcp = McpConfig()
+    assert mcp.github is None
+    assert mcp.linear is None
+
+
+def test_mcp_config_parses_servers() -> None:
+    config = OctomateConfig(
+        mcp={
+            "github": {"enabled": True, "token": "ghp_test", "read_only": True},
+            "linear": {"enabled": True, "token": "lin_test"},
+        }
+    )
+
+    assert isinstance(config.mcp.github, GitHubMcpConfig)
+    assert config.mcp.github.enabled is True
+    assert config.mcp.github.read_only is True
+    assert config.mcp.github.token is not None
+    assert config.mcp.github.token.get_secret_value() == "ghp_test"
+    assert config.mcp.github.url == "https://api.githubcopilot.com/mcp/"
+
+    assert isinstance(config.mcp.linear, LinearMcpConfig)
+    assert config.mcp.linear.url == "https://mcp.linear.app/mcp"
+
+
+def test_mcp_token_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OCTOMATE__MCP__GITHUB__ENABLED", "true")
+    monkeypatch.setenv("OCTOMATE__MCP__GITHUB__TOKEN", "ghp_env")
+
+    config = OctomateConfig()
+
+    assert config.mcp.github is not None
+    assert config.mcp.github.token is not None
+    assert config.mcp.github.token.get_secret_value() == "ghp_env"
 
 
 def test_channel_stream_config_uses_partial_defaults_from_yaml(


### PR DESCRIPTION
## What

Give the inkling agent **GitHub** and **Linear** tools by connecting to each vendor's hosted MCP server over Streamable HTTP, on a single operator token each (no Docker/npx/OAuth).

## How

- **Config** — new `mcp` section (`McpConfig` + `GitHubMcpConfig`/`LinearMcpConfig`); env `OCTOMATE__MCP__GITHUB__TOKEN` / `OCTOMATE__MCP__LINEAR__TOKEN`; commented stub in `octomate.default.yaml`.
- **Builder** — `build_mcp_toolsets()`: `MCPToolset(url, headers={Authorization: Bearer …}).prefixed(<vendor>).defer_loading()`.
  - **Bearer** auth for both (Linear's hosted MCP rejects a raw key with 401).
  - **Per-vendor prefixes** (`github_…`, `linear_…`) — required, since both servers expose `list_issues` and pydantic-ai rejects the collision.
  - **Deferred loading** so tools stay hidden until the model finds them via the auto-injected `ToolSearch`.
  - GitHub `read_only` selects the `/readonly` endpoint; enabled-without-token fails fast.
- **Lifecycle** — `Tentacle` is now an async context manager (`__aenter__`/`__aexit__`) instead of `activate`/`deactivate`; the host lifespan just enters every tentacle. Agents keep **warm MCP sessions** for the process; channels own their receive loop (Napcat in a background task; Slack/Lark inline). Removed dead `close()` and inlined `_disconnect`.
- **Misc** — suppress the intentional `pydantic-graph` v1 deprecation warning; fix `.vscode/launch.json` to run the `create_app` factory (`--factory`).

## Tests

`tests/agent/test_mcp.py` (config parse/env, builder bearer/readonly/prefix/order, agent + channel lifecycle) plus updates to channel/config tests. Full suite: **246 passed, 11 skipped**; ruff clean. Verified live: both servers connect and an agent enters both with no name collision.

## Notes

- Shared operator token, not per-user — per-user OAuth/identity is deferred (see plan doc).
- `docs/plans/github-linear-mcp.md` updated to match the implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)